### PR TITLE
Add `/v2` directory to Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,9 @@ updates:
       interval: "weekly"
     labels:
       - "dependencies"
+  - package-ecosystem: "gomod"
+    directory: "/v2"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"


### PR DESCRIPTION
The dependencies of the `v2` `go.mod` have not been updated through dependabot as the configuration has been missing. Unfortunately, it is [not possible to express this more succinctly](https://github.com/dependabot/dependabot-core/issues/2178).